### PR TITLE
User sign in - login page and redirect to index if not logged in

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,8 @@ module Acebook
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Automatically loads any files in the lib path
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,10 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  # Enables CustomFailure class for redirect to root URL to be used
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+  end
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,8 @@ Rails.application.routes.draw do
       root 'devise/sessions#new', as: :unauthenticated_root
     end
   end
+
+  root :to => redirect("/users/sign_in")
+
   resources :posts
 end

--- a/lib/custom_failure.rb
+++ b/lib/custom_failure.rb
@@ -1,0 +1,14 @@
+class CustomFailure < Devise::FailureApp
+  def redirect_url
+    new_user_session_url(:subdomain => 'secure')
+  end
+
+  # Redirect to root_url
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect_to root_url
+    end
+  end
+end

--- a/spec/custom_failure_spec.rb
+++ b/spec/custom_failure_spec.rb
@@ -1,0 +1,6 @@
+require 'custom_failure'
+require 'rails_helper'
+
+RSpec.describe CustomFailure, type: :model do
+  it { is_expected.to be }
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+require 'sign_up_helper'
+
+RSpec.feature "Sign in", type: :feature do
+  scenario "User redirected if not signed in & visits posts" do 
+    visit '/posts'
+    expect(page).to have_content("Log in")
+    expect(page).to have_button("Log in")
+  end
+
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -2,10 +2,15 @@ require 'rails_helper'
 require 'sign_up_helper'
 
 RSpec.feature "Sign in", type: :feature do
-  scenario "User redirected if not signed in & visits posts" do 
+  scenario "User redirected if not signed in & visits posts, then prompted to sign in" do 
     visit '/posts'
     expect(page).to have_content("Log in")
     expect(page).to have_button("Log in")
+  end
+
+  scenario "User redirected if not signed in & visits posts" do 
+    visit '/posts'
+    expect(page).to have_current_path("/users/sign_in")
   end
 
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Sign in", type: :feature do
     expect(page).to have_button("Log in")
   end
 
-  xscenario "User redirected if not signed in & visits posts" do
+  scenario "User redirected to index if not signed in & tries to visit posts" do
     visit '/posts'
     expect(page).to have_current_path("/")
   end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -2,15 +2,17 @@ require 'rails_helper'
 require 'sign_up_helper'
 
 RSpec.feature "Sign in", type: :feature do
-  scenario "User redirected if not signed in & visits posts, then prompted to sign in" do 
+  scenario "User redirected if not signed in & visits posts, then prompted to sign in" do
     visit '/posts'
     expect(page).to have_content("Log in")
+    expect(page).to have_field("user_email")
+    expect(page).to have_field("user_password")
     expect(page).to have_button("Log in")
   end
 
-  scenario "User redirected if not signed in & visits posts" do 
+  xscenario "User redirected if not signed in & visits posts" do
     visit '/posts'
-    expect(page).to have_current_path("/users/sign_in")
+    expect(page).to have_current_path("/")
   end
 
 end


### PR DESCRIPTION
Part of user sign in is implemented - log out is now a blocker to the remaining sign in functionality

**User story 1**
```
As PlaiceBook admin,
So that users cannot see posts without an account
I want users to be redirected to the login/signup index page
```
- Adds CustomFailure for Devise for redirect_url - see commit history

**User story 2**
```
As a user,
So that I can see people's posts
I want to be able to enter my credentials to login
```