### PR TITLE
User sign in redirect to posts & updates README with badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=c81bb354071f6fb61c6b5cf0034e1ed458483b293fd943f017aaef2c9739f2f6
+
 language: ruby
 
 rvm: '2.5.0'
@@ -5,6 +9,12 @@ rvm: '2.5.0'
 before_script:
   - bundle exec rails db:create RAILS_ENV=test
   - bundle exec rails db:migrate RAILS_ENV=test
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 
 script:
   - bundle exec rspec
+
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PlaiceBook
 
-[![Build Status](https://travis-ci.org/amyj0rdan/acebook-plaicebook.svg?branch=master)](https://travis-ci.org/amyj0rdan/acebook-plaicebook) [![Maintainability](https://api.codeclimate.com/v1/badges/e6302f17e3033f9ccd47/maintainability)](https://codeclimate.com/github/amyj0rdan/acebook-plaicebook/maintainability)
+[![Build Status](https://travis-ci.org/amyj0rdan/acebook-plaicebook.svg?branch=master)](https://travis-ci.org/amyj0rdan/acebook-plaicebook) [![Maintainability](https://api.codeclimate.com/v1/badges/e6302f17e3033f9ccd47/maintainability)](https://codeclimate.com/github/amyj0rdan/acebook-plaicebook/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/e6302f17e3033f9ccd47/test_coverage)](https://codeclimate.com/github/amyj0rdan/acebook-plaicebook/test_coverage)
 
 ![plaicebook gif](https://media.giphy.com/media/xUPGcuPLCKs0LiYnCg/giphy.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PlaiceBook
 
+[![Build Status](https://travis-ci.org/amyj0rdan/acebook-plaicebook.svg?branch=master)](https://travis-ci.org/amyj0rdan/acebook-plaicebook) [![Maintainability](https://api.codeclimate.com/v1/badges/e6302f17e3033f9ccd47/maintainability)](https://codeclimate.com/github/amyj0rdan/acebook-plaicebook/maintainability)
+
 ![plaicebook gif](https://media.giphy.com/media/xUPGcuPLCKs0LiYnCg/giphy.gif)
 
 1. The engineering project outline is [here](https://github.com/makersacademy/course/tree/master/engineering_projects/rails).

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -16,4 +16,13 @@ RSpec.feature "Sign in", type: :feature do
     expect(page).to have_current_path("/")
   end
 
+  scenario "User signs in and is redirected to the posts page" do
+    create_user_and_sign_up
+    click_button("Sign out")
+    click_link("Log in")
+    fill_in("user_email", with: "georgie@com")
+    fill_in("user_password", with: "password1")
+    click_button("Log in")
+    expect(page).to have_link('New post')
+  end
 end


### PR DESCRIPTION
Adds feature test for:

```
As a user,
So that I can create and read posts
I want to go to the posts page once I have logged in
```

Also updates README with badges. Test coverage won't display properly until this is merged into master.