### PR TITLE
db migration to use 'user_id' foreign_key rather than 'liker'

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,7 +1,7 @@
 class LikesController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
-    @like = @post.likes.create!(liker: current_user.id)
+    @like = @post.likes.create!(user_id: current_user.id)
     redirect_to posts_path
   end
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,8 +11,8 @@
     <p id="number_of_likes"><%= post.likes.length %></p>
 
     <div id="like-form">
-      <% if post.likes.find { |like| like.liker === current_user.id } %>
-        <% like = post.likes.find { |like| like.liker === current_user.id } %>
+      <% if post.likes.find { |like| like.user_id === current_user.id } %>
+        <% like = post.likes.find { |like| like.user_id === current_user.id } %>
         <%= button_to '', post_like_path(post, like), method: :delete, :class => "unlike-button" %>
       <% else %>
         <%= button_to '', post_likes_path(post), method: :post, :class => "like-button" %>

--- a/db/migrate/20190501124635_add_user_to_likes.rb
+++ b/db/migrate/20190501124635_add_user_to_likes.rb
@@ -1,0 +1,5 @@
+class AddUserToLikes < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :likes, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190501124755_remove_liker_from_likes.rb
+++ b/db/migrate/20190501124755_remove_liker_from_likes.rb
@@ -1,0 +1,5 @@
+class RemoveLikerFromLikes < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :likes, :liker, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190430093615) do
+ActiveRecord::Schema.define(version: 20190501124755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,11 +26,12 @@ ActiveRecord::Schema.define(version: 20190430093615) do
   end
 
   create_table "likes", force: :cascade do |t|
-    t.integer "liker"
     t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -56,5 +57,6 @@ ActiveRecord::Schema.define(version: 20190430093615) do
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   end
 
   factory :like do
-    liker { 1 }
+    user { 1 }
     post { nil }
   end
 


### PR DESCRIPTION
Refactors `likes` table to use correct foreign key for user